### PR TITLE
Use error type in default error pages

### DIFF
--- a/lib/gopher2000/base.rb
+++ b/lib/gopher2000/base.rb
@@ -481,15 +481,15 @@ module Gopher
     #
     def register_defaults
       menu :'internal/not_found' do
-        text "Sorry, #{@request.selector} was not found"
+        error "Sorry, #{@request.selector} was not found"
       end
 
       menu :'internal/error' do |details|
-        text "Sorry, there was an error #{details}"
+        error "Sorry, there was an error #{details}"
       end
 
       menu :'internal/invalid_request' do
-        text "invalid request"
+        error "invalid request"
       end
     end
 

--- a/spec/dispatching_spec.rb
+++ b/spec/dispatching_spec.rb
@@ -51,6 +51,7 @@ describe Gopher::Application do
 
       @response = @server.dispatch(@request)
       expect(@response.code).to eq(:missing)
+      expect(@response.body).to contain_any_error
     end
 
     it "should respond with error if invalid request" do
@@ -59,6 +60,7 @@ describe Gopher::Application do
 
       @response = @server.dispatch(@request)
       expect(@response.code).to eq(:error)
+      expect(@response.body).to contain_any_error
     end
 
     it "should respond with error if there's an exception" do
@@ -67,6 +69,7 @@ describe Gopher::Application do
 
       @response = @server.dispatch(@request)
       expect(@response.code).to eq(:error)
+      expect(@response.body).to contain_any_error
     end
   end
 
@@ -139,6 +142,14 @@ describe Gopher::Application do
       @request = Gopher::Request.new("/about/a/b")
       @response = @server.dispatch(@request)
       expect(@response.body).to eq("a/b")
+    end
+  end
+end
+
+RSpec::Matchers.define :contain_any_error do
+  match do |actual|
+    actual.split(/\r?\n/).any? do |line| 
+      line.match(/^3.*?\tnull\t\(FALSE\)\t0$/)
     end
   end
 end


### PR DESCRIPTION
Following on from https://github.com/muffinista/gopherpedia.com/pull/5, this PR introduces error types to the default error pages.

I'm not especially confident with Ruby, so please let me know if I'm doing anything unpleasant and I'll fix it up.