### PR TITLE
Add code to attempt to handle stray period lines #1

### DIFF
--- a/lib/gopher2000/rendering/base.rb
+++ b/lib/gopher2000/rendering/base.rb
@@ -35,7 +35,7 @@ module Gopher
       # @param [String] string text to add to the output
       #
       def <<(string)
-        @result << string.to_s
+        @result << clean_line(string.to_s)
       end
 
       #
@@ -89,7 +89,9 @@ module Gopher
         # this is a hack - recombine lines, then re-split on newlines
         # doing this because word_wrap is returning an array of lines, but
         # those lines have newlines in them where we should wrap
-        lines = word_wrap(text, width).join("\n").split("\n")
+        #
+        lines = word_wrap(text, width)
+                  .join("\n").split("\n")
 
         lines.each do |line|
           text line.lstrip.rstrip
@@ -206,6 +208,19 @@ module Gopher
         end
       end
 
+      #
+      # handle lines of a single period not at the end of the
+      # transmission
+      #
+      # RFC 1436 states: Note: Lines beginning with
+      # periods must be prepended with an extra period to
+      # ensure that the transmission is not terminated
+      # early. The client should strip extra periods at
+      # the beginning of the line.
+      def clean_line(line)
+        line.match?(/^\./) ? ['.', line].join('') : line
+      end
+      
       private
       def add_spacing
         br(@spacing)

--- a/spec/rendering/base_spec.rb
+++ b/spec/rendering/base_spec.rb
@@ -10,7 +10,7 @@ describe Gopher::Rendering::Base do
     @ctx.text("line 2")
     expect(@ctx.result).to eq("line 1\r\nline 2\r\n")
   end
-
+  
   it "should add breaks correctly" do
     @ctx.spacing 2
     @ctx.text("line 1")
@@ -18,6 +18,13 @@ describe Gopher::Rendering::Base do
     expect(@ctx.result).to eq("line 1\r\n\r\nline 2\r\n\r\n")
   end
 
+  it "should add extra period to lines beginning with period" do
+    @ctx.text("line 1")
+    @ctx.text(".")
+    @ctx.text("line 2")
+    expect(@ctx.result).to eq("line 1\r\n..\r\nline 2\r\n")
+  end
+  
   it "br outputs a bunch of newlines" do
     expect(@ctx.br(2)).to eq("\r\n\r\n")
   end
@@ -60,7 +67,12 @@ describe Gopher::Rendering::Base do
   describe "block" do
     it "wraps text" do
       expect(@ctx).to receive(:text).twice.with "a"
-      @ctx.block("a a",1)
+      @ctx.block("a a", 1)
+    end
+
+    it "handles stray period" do
+      @ctx.block("a a .", 1)
+      expect(@ctx.result).to eq("a\r\na\r\n..\r\n")
     end
   end
 end


### PR DESCRIPTION
This should implement the bit of RFC 1436 which says a line starting
with a single period should prepend an extra period so the client
doesn't close the connection.